### PR TITLE
fix(deps): update vite to resolve GHSA-p9ff-h696-f583

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3318,9 +3318,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Updates vite to patch arbitrary file read vulnerability via dev server WebSocket (GHSA-p9ff-h696-f583)
- Also resolves GHSA-4w7w-66w2-5vf9 and GHSA-v2wj-q39q-566r
- `npm audit` now reports 0 vulnerabilities; all 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)