### PR TITLE
chore: repo review cleanup and doc refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ d3.selectAll(".dot").sonify({
   pan: { range: [-0.7, 0.7] },
   duration: 200,
   gap: 50,
-  mode: "discrete",  // or "continuous"
+  mode: "discrete",          // or "continuous"
+  instrument: "sine",        // sine | triangle | square | sawtooth
   accessibility: { keyboard: true, announce: true, focus: true, hover: true }
 }
 ```

--- a/docs/FEEDBACK_OUTREACH.md
+++ b/docs/FEEDBACK_OUTREACH.md
@@ -420,13 +420,13 @@ Post on instances like `a]y.info` or `dragonscave.space` which have strong acces
 
 ---
 
-*Last updated: December 2024*
+*Last updated: April 2026*
 
 ---
 
 ## Release Status
 
-**✅ npm package published:** `npm install sound3fy` (v0.1.1)
+**✅ npm package published:** `npm install sound3fy` (v0.1.2)
 
 The library is now available on npm with:
 - ESM and UMD builds

--- a/docs/research/RESEARCH_SUMMARY.md
+++ b/docs/research/RESEARCH_SUMMARY.md
@@ -1,7 +1,7 @@
 # Expert Panel Review Summary
 
-**Date:** December 2025
-**Status:** Ready for user testing
+**Date:** December 2025 (published), last reviewed April 2026
+**Status:** Released on npm, gathering user feedback
 
 ---
 
@@ -20,15 +20,18 @@ Five experts (D3, Accessibility, Audio, Principal Dev, Owner) reviewed the codeb
 | D3 Integration | Dara Chen | Clean plugin pattern, idiomatic API |
 | Accessibility | Maya Richardson | Keyboard nav works, ARIA implemented, WCAG compliant |
 | Audio | Jordan Okonkwo | Safe frequencies (220-880Hz), pleasant ADSR envelope |
-| Code Quality | Priya Sharma | 700 lines, zero runtime deps, tests passing |
+| Code Quality | Priya Sharma | ~700 lines, zero runtime deps, tests passing |
 
 ---
 
 ## Completed Fixes
 
 - [x] Try-catch in AudioEngine.init() for iOS/Safari errors
-- [x] Console warning when D3.js not detected  
+- [x] Console warning when D3.js not detected
 - [x] TypeScript definitions (sound3fy.d.ts)
+- [x] Published to npm (`npm install sound3fy`)
+- [x] Posted to r/Blind, Hacker News, Medium, LinkedIn (see FEEDBACK_OUTREACH.md)
+- [x] Instrument option (sine/triangle/square/sawtooth) wired through the engine
 
 ---
 
@@ -42,10 +45,9 @@ Five experts (D3, Accessibility, Audio, Principal Dev, Owner) reviewed the codeb
 
 ## Next Actions
 
-### Immediate (This Week)
-1. **Post to r/Blind** - Get feedback from actual users
-2. **Post to AppleVis** - VoiceOver-specific feedback
-3. **Post to WebAIM** - Accessibility practitioner input
+### Outstanding Outreach
+- **AppleVis** - VoiceOver-specific feedback (pending)
+- **WebAIM list** - Accessibility practitioner input (pending)
 
 ### Based on User Feedback
 - Prioritize issues real users encounter

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/sound3fy.d.ts
+++ b/sound3fy.d.ts
@@ -5,6 +5,7 @@
 export type ScaleType = 'pentatonic' | 'major' | 'minor' | 'blues' | 'chromatic' | 'continuous';
 export type PlaybackMode = 'discrete' | 'continuous';
 export type ChartType = 'bar' | 'line' | 'scatter';
+export type Instrument = 'sine' | 'triangle' | 'square' | 'sawtooth';
 
 export interface PitchConfig {
   field?: string | ((datum: any, index: number) => number) | null;
@@ -45,6 +46,7 @@ export interface SonifyOptions {
   mode?: PlaybackMode;
   chartType?: ChartType;
   x?: string | ((datum: any, index: number) => number);
+  instrument?: Instrument;
   envelope?: EnvelopeConfig;
   markers?: { start?: boolean; end?: boolean };
   accessibility?: AccessibilityConfig;
@@ -55,7 +57,7 @@ export class AudioEngine {
   constructor();
   init(): this;
   resume(): Promise<void>;
-  playTone(options?: { frequency?: number; duration?: number; volume?: number; pan?: number; envelope?: EnvelopeConfig }): this;
+  playTone(options?: { frequency?: number; duration?: number; volume?: number; pan?: number; envelope?: EnvelopeConfig; instrument?: Instrument }): this;
   valueToFrequency(value: number, options?: { minFreq?: number; maxFreq?: number; scale?: ScaleType }): number;
   playMarker(type: 'start' | 'end'): this;
   getContext(): AudioContext;

--- a/src/core/AudioEngine.js
+++ b/src/core/AudioEngine.js
@@ -11,6 +11,10 @@ const SCALES = {
   blues: [0, 3, 5, 6, 7, 10]
 };
 
+// Oscillator waveforms supported by the Web Audio API
+const WAVEFORMS = ['sine', 'triangle', 'square', 'sawtooth'];
+export const resolveWaveform = (w) => WAVEFORMS.includes(w) ? w : 'sine';
+
 const A4 = 440;
 const midiToFreq = (midi) => A4 * Math.pow(2, (midi - 69) / 12);
 
@@ -57,7 +61,7 @@ export class AudioEngine {
     const gain = ctx.createGain();
     const panner = ctx.createStereoPanner();
 
-    osc.type = ['sine', 'triangle', 'square', 'sawtooth'].includes(instrument) ? instrument : 'sine';
+    osc.type = resolveWaveform(instrument);
     osc.frequency.value = frequency;
     panner.pan.value = Math.max(-1, Math.min(1, pan));
     

--- a/src/core/AudioEngine.js
+++ b/src/core/AudioEngine.js
@@ -45,18 +45,19 @@ export class AudioEngine {
   /**
    * Play a tone with ADSR envelope
    */
-  playTone({ frequency = 440, duration = 0.2, volume = 0.5, pan = 0, envelope = {} } = {}) {
+  playTone({ frequency = 440, duration = 0.2, volume = 0.5, pan = 0, envelope = {}, instrument = 'sine' } = {}) {
     this.init();
-    
+    if (!this.context) return this;
+
     const ctx = this.context;
     const now = ctx.currentTime;
     const { attack = 0.02, decay = 0.05, sustain = 0.7, release = 0.1 } = envelope;
-    
+
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     const panner = ctx.createStereoPanner();
-    
-    osc.type = 'sine';
+
+    osc.type = ['sine', 'triangle', 'square', 'sawtooth'].includes(instrument) ? instrument : 'sine';
     osc.frequency.value = frequency;
     panner.pan.value = Math.max(-1, Math.min(1, pan));
     

--- a/src/core/DataMapper.js
+++ b/src/core/DataMapper.js
@@ -32,8 +32,6 @@ export class DataMapper {
         this.extents.x = { min: Math.min(...xValues), max: Math.max(...xValues) };
       }
     }
-    
-    this.extent = this.extents.pitch; // Backward compat
   }
   
   /** Get numeric value from datum */

--- a/src/core/DataMapper.test.js
+++ b/src/core/DataMapper.test.js
@@ -22,52 +22,52 @@ describe('DataMapper', () => {
         { datum: { value: 50 }, index: 1 },
         { datum: { value: 30 }, index: 2 }
       ];
-      
+
       mapper.analyze(data);
-      
-      expect(mapper.extent).toEqual({ min: 10, max: 50 });
+
+      expect(mapper.extents.pitch).toEqual({ min: 10, max: 50 });
     });
-    
+
     it('should handle empty data', () => {
       const mapper = new DataMapper();
       mapper.analyze([]);
-      expect(mapper.extent).toBeUndefined();
+      expect(mapper.extents.pitch).toBeUndefined();
     });
-    
+
     it('should auto-detect value field', () => {
       const mapper = new DataMapper();
       const data = [
         { datum: { value: 100 }, index: 0 },
         { datum: { value: 200 }, index: 1 }
       ];
-      
+
       mapper.analyze(data);
-      
-      expect(mapper.extent).toEqual({ min: 100, max: 200 });
+
+      expect(mapper.extents.pitch).toEqual({ min: 100, max: 200 });
     });
-    
+
     it('should handle numeric datum directly', () => {
       const mapper = new DataMapper();
       const data = [
         { datum: 5, index: 0 },
         { datum: 15, index: 1 }
       ];
-      
+
       mapper.analyze(data);
-      
-      expect(mapper.extent).toEqual({ min: 5, max: 15 });
+
+      expect(mapper.extents.pitch).toEqual({ min: 5, max: 15 });
     });
-    
+
     it('should use accessor function', () => {
       const mapper = new DataMapper({ pitch: { field: d => d.x * 2 } });
       const data = [
         { datum: { x: 10 }, index: 0 },
         { datum: { x: 20 }, index: 1 }
       ];
-      
+
       mapper.analyze(data);
-      
-      expect(mapper.extent).toEqual({ min: 20, max: 40 });
+
+      expect(mapper.extents.pitch).toEqual({ min: 20, max: 40 });
     });
   });
   
@@ -77,63 +77,63 @@ describe('DataMapper', () => {
         pitch: { field: 'value', range: [200, 800] },
         duration: 300
       });
-      
-      mapper.extent = { min: 0, max: 100 };
-      
+
+      mapper.extents.pitch = { min: 0, max: 100 };
+
       const item = { datum: { value: 50 }, index: 0 };
       const params = mapper.map(item, 0, 1);
-      
+
       expect(params).toHaveProperty('frequency');
       expect(params).toHaveProperty('volume');
       expect(params).toHaveProperty('pan');
       expect(params.duration).toBe(0.3);
     });
-    
+
     it('should map pan based on position', () => {
       const mapper = new DataMapper({ pan: { range: [-1, 1] } });
-      mapper.extent = { min: 0, max: 100 };
-      
+      mapper.extents.pitch = { min: 0, max: 100 };
+
       const item = { datum: { value: 50 }, index: 5 };
       const params = mapper.map(item, 5, 11);
-      
+
       expect(params.pan).toBe(0); // Middle position
     });
-    
+
     it('should return center pan for single item', () => {
       const mapper = new DataMapper();
-      mapper.extent = { min: 0, max: 100 };
-      
+      mapper.extents.pitch = { min: 0, max: 100 };
+
       const params = mapper.map({ datum: 50, index: 0 }, 0, 1);
-      
+
       expect(params.pan).toBe(0);
     });
   });
-  
+
   describe('mapVolume()', () => {
     it('should return default volume without field', () => {
       const mapper = new DataMapper();
       const volume = mapper.mapVolume({ datum: { value: 50 }, index: 0 });
       expect(volume).toBe(0.5);
     });
-    
+
     it('should map volume from field', () => {
       const mapper = new DataMapper({
         volume: { field: 'importance', range: [0.2, 0.8] }
       });
-      mapper.extent = { min: 0, max: 100 };
-      
+      mapper.extents.pitch = { min: 0, max: 100 };
+
       const volume = mapper.mapVolume({ datum: { importance: 50 }, index: 0 });
-      
+
       expect(volume).toBeGreaterThanOrEqual(0.2);
       expect(volume).toBeLessThanOrEqual(0.8);
     });
   });
-  
+
   describe('describe()', () => {
     it('should generate description with label', () => {
       const mapper = new DataMapper({ pitch: { field: 'value' } });
-      mapper.extent = { min: 0, max: 100 };
-      
+      mapper.extents.pitch = { min: 0, max: 100 };
+
       const desc = mapper.describe(
         { datum: { name: 'January', value: 42 }, index: 0 },
         0, 12

--- a/src/core/SonificationEngine.js
+++ b/src/core/SonificationEngine.js
@@ -2,7 +2,7 @@
  * SonificationEngine - Orchestrates audio playback with accessibility
  */
 
-import { AudioEngine } from './AudioEngine.js';
+import { AudioEngine, resolveWaveform } from './AudioEngine.js';
 import { DataMapper } from './DataMapper.js';
 
 export class SonificationEngine {
@@ -149,8 +149,7 @@ export class SonificationEngine {
     this.sweepGain = ctx.createGain();
     const panner = ctx.createStereoPanner();
     
-    const instrument = this.options.instrument;
-    this.sweepOsc.type = ['sine', 'triangle', 'square', 'sawtooth'].includes(instrument) ? instrument : 'sine';
+    this.sweepOsc.type = resolveWaveform(this.options.instrument);
     this.sweepOsc.connect(this.sweepGain);
     this.sweepGain.connect(panner);
     panner.connect(this.audio.getMasterGain());

--- a/src/core/SonificationEngine.js
+++ b/src/core/SonificationEngine.js
@@ -128,7 +128,8 @@ export class SonificationEngine {
     const params = this.mapper.map(item, idx, this.data.length);
     params.duration /= this.speed;
     params.envelope = this.options.envelope;
-    
+    params.instrument = this.options.instrument;
+
     this.audio.playTone(params);
     if (announce) this.announce(this.mapper.describe(item, idx, this.data.length));
     this.updateFocus(item.element);
@@ -148,7 +149,8 @@ export class SonificationEngine {
     this.sweepGain = ctx.createGain();
     const panner = ctx.createStereoPanner();
     
-    this.sweepOsc.type = 'sine';
+    const instrument = this.options.instrument;
+    this.sweepOsc.type = ['sine', 'triangle', 'square', 'sawtooth'].includes(instrument) ? instrument : 'sine';
     this.sweepOsc.connect(this.sweepGain);
     this.sweepGain.connect(panner);
     panner.connect(this.audio.getMasterGain());

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const DEFAULTS = {
   duration: 200,
   gap: 50,
   mode: 'discrete',
+  instrument: 'sine',
   envelope: { attack: 0.02, decay: 0.05, sustain: 0.7, release: 0.1 },
   markers: { start: false, end: false },
   accessibility: { keyboard: true, announce: true, focus: true, hover: true },


### PR DESCRIPTION
- Wire the `instrument` option (sine/triangle/square/sawtooth) through
  AudioEngine and SonificationEngine (both discrete and continuous modes).
  The demo UI exposed this option but the engine silently ignored it.
- Guard AudioEngine.playTone against browsers without Web Audio API.
- Drop the `DataMapper.extent` backward-compat shim and point tests at
  `extents.pitch` directly.
- Remove unused `renovate.json` (Dependabot is the active bot).
- Refresh stale dates and outreach status in docs/FEEDBACK_OUTREACH.md
  and docs/research/RESEARCH_SUMMARY.md; document `instrument` in README
  and TypeScript definitions.