### PR TITLE
feat: honor prefers-reduced-motion by downgrading continuous mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Built for WCAG 2.2 compliance:
 - **ARIA**: `role="graphics-symbol"`, `aria-label`, `aria-live="polite"`
 - **Keyboard**: Full navigation
 - **Focus**: Visual indicators with high contrast support
-- **Reduced Motion**: Respects user preferences
+- **Reduced Motion**: When `prefers-reduced-motion: reduce` is set, continuous
+  sweep mode falls back to discrete note-by-note playback. Disable with
+  `accessibility: { respectReducedMotion: false }`.
 
 ## Development
 

--- a/sound3fy.d.ts
+++ b/sound3fy.d.ts
@@ -35,6 +35,11 @@ export interface AccessibilityConfig {
   announceSummary?: boolean;
   focus?: boolean;
   hover?: boolean;
+  /**
+   * When true (default), continuous sweep mode is downgraded to discrete
+   * playback if the user has set `prefers-reduced-motion: reduce`.
+   */
+  respectReducedMotion?: boolean;
 }
 
 export interface SonifyOptions {

--- a/src/core/AudioEngine.js
+++ b/src/core/AudioEngine.js
@@ -15,6 +15,17 @@ const SCALES = {
 const WAVEFORMS = ['sine', 'triangle', 'square', 'sawtooth'];
 export const resolveWaveform = (w) => WAVEFORMS.includes(w) ? w : 'sine';
 
+/** Whether the user has requested reduced motion via OS/browser preferences. */
+export const prefersReducedMotion = () => {
+  try {
+    return typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (_e) {
+    return false;
+  }
+};
+
 const A4 = 440;
 const midiToFreq = (midi) => A4 * Math.pow(2, (midi - 69) / 12);
 

--- a/src/core/SonificationEngine.js
+++ b/src/core/SonificationEngine.js
@@ -2,7 +2,7 @@
  * SonificationEngine - Orchestrates audio playback with accessibility
  */
 
-import { AudioEngine, resolveWaveform } from './AudioEngine.js';
+import { AudioEngine, resolveWaveform, prefersReducedMotion } from './AudioEngine.js';
 import { DataMapper } from './DataMapper.js';
 
 export class SonificationEngine {
@@ -18,7 +18,14 @@ export class SonificationEngine {
     this.paused = false;
     this.timer = null;
     this.speed = 1;
-    this.mode = options.mode || 'discrete';
+
+    // Continuous mode sweeps frequency and pan over time; honor the user's
+    // reduced-motion preference by downgrading to discrete unless opted out.
+    const requestedMode = options.mode || 'discrete';
+    const respectReducedMotion = options.accessibility?.respectReducedMotion !== false;
+    this.mode = (requestedMode === 'continuous' && respectReducedMotion && prefersReducedMotion())
+      ? 'discrete'
+      : requestedMode;
     
     this.liveRegion = null;
     this._keyHandler = null;

--- a/src/core/SonificationEngine.test.js
+++ b/src/core/SonificationEngine.test.js
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // Mock AudioEngine - must be before import
+const prefersReducedMotionMock = vi.fn().mockReturnValue(false);
 vi.mock('./AudioEngine.js', () => {
   const AudioEngine = function() {
     this.init = vi.fn().mockReturnThis();
@@ -15,7 +16,11 @@ vi.mock('./AudioEngine.js', () => {
     this.getMasterGain = vi.fn().mockReturnValue({ connect: vi.fn() });
     this.destroy = vi.fn();
   };
-  return { AudioEngine };
+  return {
+    AudioEngine,
+    resolveWaveform: (w) => w || 'sine',
+    prefersReducedMotion: (...args) => prefersReducedMotionMock(...args)
+  };
 });
 
 // Mock DataMapper
@@ -291,6 +296,47 @@ describe('SonificationEngine', () => {
     });
   });
   
+  describe('prefers-reduced-motion', () => {
+    afterEach(() => {
+      prefersReducedMotionMock.mockReturnValue(false);
+    });
+
+    it('downgrades continuous mode to discrete when preference is set', () => {
+      prefersReducedMotionMock.mockReturnValue(true);
+      const e = new SonificationEngine({ mode: 'continuous' });
+      expect(e.mode).toBe('discrete');
+    });
+
+    it('leaves discrete mode alone when preference is set', () => {
+      prefersReducedMotionMock.mockReturnValue(true);
+      const e = new SonificationEngine({ mode: 'discrete' });
+      expect(e.mode).toBe('discrete');
+    });
+
+    it('keeps continuous mode when preference is not set', () => {
+      prefersReducedMotionMock.mockReturnValue(false);
+      const e = new SonificationEngine({ mode: 'continuous' });
+      expect(e.mode).toBe('continuous');
+    });
+
+    it('keeps continuous mode when respectReducedMotion is disabled', () => {
+      prefersReducedMotionMock.mockReturnValue(true);
+      const e = new SonificationEngine({
+        mode: 'continuous',
+        accessibility: { respectReducedMotion: false }
+      });
+      expect(e.mode).toBe('continuous');
+    });
+
+    it('setMode() always respects the caller even with reduced-motion', () => {
+      prefersReducedMotionMock.mockReturnValue(true);
+      const e = new SonificationEngine({ mode: 'continuous' });
+      expect(e.mode).toBe('discrete');
+      e.setMode('continuous');
+      expect(e.mode).toBe('continuous');
+    });
+  });
+
   describe('setMode()', () => {
     it('should set continuous mode', () => {
       engine.setMode('continuous');


### PR DESCRIPTION
README claimed "Respects user preferences" for reduced motion but nothing
in the engine checked the media query. Continuous sweep mode performs
continuous frequency and pan ramps over time, which is the motion-analog
most worth gating behind the preference.

- Add `prefersReducedMotion()` helper in AudioEngine (safe in SSR / no
  matchMedia).
- In SonificationEngine constructor, when `options.mode === 'continuous'`
  and the user prefers reduced motion, fall back to discrete playback.
- Add `accessibility.respectReducedMotion` (default true) as an opt-out
  so callers can keep continuous sweep if they know their users want it.
- Leave explicit runtime `setMode('continuous')` calls (including the M
  keyboard shortcut) untouched — those are explicit user intent.
- Update TypeScript definitions and README to describe the behavior.
- Cover with five unit tests (downgrade, discrete unchanged, no-pref
  unchanged, opt-out, runtime override).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reduced motion accessibility support. When users set `prefers-reduced-motion: reduce` in system preferences, continuous sweep mode automatically switches to discrete note-by-note playback.
  * Added `respectReducedMotion` configuration option to opt out of this behavior.

* **Tests**
  * Added comprehensive test coverage for reduced motion behavior and configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->