### PR TITLE
chore: add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 0'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Adds a CodeQL workflow analysing JavaScript/TypeScript on push, PR, and weekly cron.
- Closes the high-priority `code-scanning` standards gap surfaced by repo-butler governance findings (portfolio coverage 4/13 → 13/13 once the sweep lands).
- Unlocks the Gold tier security-trifecta check (Dependabot + code scanning + secret scanning).

## Test plan
- [ ] CodeQL workflow runs successfully on this PR
- [ ] No new alerts (or any are reviewed before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)